### PR TITLE
ProxyBuilder/ProxyClient: do not proxy default methods

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -12,6 +12,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Set;
@@ -27,6 +28,11 @@ public class ProxyBuilder<T>
    public static <T> ProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget)
    {
       return new ProxyBuilder<T>(iface, (ResteasyWebTarget)webTarget);
+   }
+
+   private static boolean isDefault(Method method) {
+      return ((method.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) ==
+         Modifier.PUBLIC) && method.getDeclaringClass().isInterface();
    }
 
 	@SuppressWarnings("unchecked")
@@ -45,7 +51,10 @@ public class ProxyBuilder<T>
 		{
          MethodInvoker invoker;
          Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
-         if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+         if (isDefault(method)) {
+            continue;
+         }
+         else if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
          {
             invoker = new SubResourceInvoker((ResteasyWebTarget)base, method, config);
          }


### PR DESCRIPTION
This allows to create default methods in shared resource interfaces that can be used for a HttpClient proxy.
Approach based on https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/

Example usage:

``` java

@Consumes(MediaType.WILDCARD)
@Produces(MediaType.APPLICATION_JSON)
interface ExampleResource {

    default Response test() {
        return test("5");
    }

    @GET
    Response test(@QueryParam("lupa") @DefaultValue("5") String value);
}

```

```
modified:   resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
modified:   resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/ClientProxy.java
```
